### PR TITLE
Enable logging from non-root MPI ranks

### DIFF
--- a/pyc2ray/c2ray_base.py
+++ b/pyc2ray/c2ray_base.py
@@ -779,11 +779,11 @@ Simulation Box size (comoving Mpc): {self.boxsize:.3e}"""
             if not self.resume:
                 self.logfile.unlink(missing_ok=True)
 
-        configure_logger(self.logfile)
-
-        # Wait here.
+        # Wait here for result directory to be created
         if self.mpi:
             MPI.COMM_WORLD.Barrier()
+
+        configure_logger(self.logfile)
 
         if self.resume:
             title = f"\n\nResuming{C2Ray.banner[8:]}\n\n"

--- a/pyc2ray/evolve.py
+++ b/pyc2ray/evolve.py
@@ -8,7 +8,7 @@ from mpi4py import MPI
 from .asora_core import is_device_init
 from .load_extensions import libasora, libc2ray
 from .utils import display_time
-from .utils.logutils import disable_newline
+from .utils.logutils import allow_rank_logging
 from .utils.sourceutils import FloatArray, IntArray, format_sources
 
 __all__ = ["evolve3D"]
@@ -131,6 +131,7 @@ def evolve3D(
     phi_ion : 3D-array
         Photoionization rate of each cell due to all sources
     """
+    rank_prefix = f"Rank={rank}: " if use_mpi else ""
 
     # Allow a call with GPU only if
     # 1. the asora library is present and
@@ -156,7 +157,6 @@ def evolve3D(
     converged = False
     if rank != 0:
         xh_new = np.empty_like(xh)
-    niter = 0
 
     # initialize average and intermediate results to values at beginning of timestep
     xh_av = np.copy(xh)
@@ -181,7 +181,8 @@ def evolve3D(
             srcpos_flat, normflux_flat = format_sources(
                 src_pos[:, i_start:i_end], src_flux[i_start:i_end]
             )
-            logger.info(f"...rank={rank:n} has {NumSrc:n} sources.")
+            with allow_rank_logging(rank):
+                logger.info(f"{rank_prefix}{NumSrc} sources.")
         else:
             srcpos_flat, normflux_flat = format_sources(src_pos, src_flux)
 
@@ -196,10 +197,8 @@ def evolve3D(
         # Copy density field to GPU once at the beginning of timestep (!! do_all_sources assumes this !!)
         assert libasora is not None
         libasora.density_to_device(ndens_flat)
-        if use_mpi:
-            logger.info("Copied source data to device.")
-        else:
-            logger.info(f"Rank {rank} copied source data to device.")
+        with allow_rank_logging(rank):
+            logger.info(f"{rank_prefix}Copied source data to device.")
 
     # -----------------------------------------------------------
     # Start Evolve step, Iterate until convergence in <x> and <y>
@@ -216,17 +215,12 @@ Convergence Criterion (Number of points): {conv_criterion: n}
 """)
 
     while not converged:
-        niter += 1
-
         # --------------------
         # (1): Raytracing Step
         # --------------------
         trt0 = time.time()
-        with disable_newline():
-            if use_mpi:
-                logger.info("Doing Raytracing...")
-            else:
-                logger.info(f"Rank={rank} is doing Raytracing...")
+        with allow_rank_logging(rank):
+            logger.info(f"{rank_prefix}Doing Raytracing...")
 
         # Do the raytracing part for each source. This computes the cumulative ionization rate for each cell.
         if use_gpu:
@@ -276,10 +270,8 @@ Convergence Criterion (Number of points): {conv_criterion: n}
             )
 
         trt1 = time.time() - trt0
-        if use_mpi:
-            logger.info(f"  rank={rank} took {display_time(trt1)}.")
-        else:
-            logger.info(f"  took {display_time(trt1)}")
+        with allow_rank_logging(rank):
+            logger.info(f"took {display_time(trt1)}.")
 
         # Since chemistry (ODE solving) is done on the CPU in Fortran, flattened CUDA arrays need to be reshaped
         if use_gpu:
@@ -304,8 +296,7 @@ Convergence Criterion (Number of points): {conv_criterion: n}
             # (2): ODE Solving Step
             # ---------------------
             tch0 = time.time()
-            with disable_newline():
-                logger.info("Doing Chemistry...")
+            logger.info("Doing Chemistry...")
             # Apply the global rates to compute the updated ionization fraction
             conv_flag = libc2ray.chemistry.global_pass(
                 dt,
@@ -330,7 +321,7 @@ Convergence Criterion (Number of points): {conv_criterion: n}
             #     clump, bh00, albpow, colh0, temph0, abu_c,
             # )
 
-            logger.info(f"  took {(time.time() - tch0): .1f} s.")
+            logger.info(f"took {(time.time() - tch0): .1f} s.")
 
             # ----------------------------
             # (3): Test Global Convergence
@@ -385,10 +376,10 @@ Convergence Criterion (Number of points): {conv_criterion: n}
                 converged = bool(converged_array[0])
 
     if rank == 0:
-        # When converged, return the updated ionization fractions at the end of the timestep
         logger.info(
             f"Multiple source convergence reached after {n_count} ray-tracing iterations."
         )
+        # When converged, return the updated ionization fractions at the end of the timestep
         xh_new = xh_intermed
 
     if use_mpi:

--- a/pyc2ray/utils/logutils.py
+++ b/pyc2ray/utils/logutils.py
@@ -22,6 +22,18 @@ def disable_newline() -> Iterator[None]:
         logging.StreamHandler.terminator = end
 
 
+@contextmanager
+def allow_rank_logging(rank: int) -> Iterator[None]:
+    """Context manager to temporarily allow logging on the specified MPI rank."""
+    default = MPIRankFilter.RANK
+    MPIRankFilter.RANK = rank
+
+    try:
+        yield
+    finally:
+        MPIRankFilter.RANK = default
+
+
 class MaxLevelFilter:
     """Filter to allow only messages up to a specific level."""
 
@@ -30,6 +42,19 @@ class MaxLevelFilter:
 
     def filter(self, record: logging.LogRecord) -> bool:
         return record.levelno <= self.level
+
+
+class MPIRankFilter:
+    """Filter to allow only messages from the given MPI rank."""
+
+    # Global rank variable that can be set to filter for a different rank.
+    RANK: int = 0
+
+    def __init__(self) -> None:
+        self._this_rank = MPI.COMM_WORLD.Get_rank()
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return self._this_rank == MPIRankFilter.RANK
 
 
 def configure_logger(
@@ -47,11 +72,6 @@ def configure_logger(
     """
     # Grab this module's logger and set level
     module_logger = logging.getLogger(__name__.partition(".")[0])
-
-    # Logging is only enabled on one MPI process
-    if MPI.COMM_WORLD.Get_rank() != 0:
-        module_logger.disabled = True
-        return
 
     # Logger was already configured
     if module_logger.handlers:
@@ -71,13 +91,16 @@ def configure_logger(
 
     # Set up console handlers for info messages to stdout
     cout = logging.StreamHandler(sys.stdout)
+    cout.setLevel(lev0)
     cout.addFilter(MaxLevelFilter(logging.INFO))
+    cout.addFilter(MPIRankFilter())
     module_logger.addHandler(cout)
 
     # Set up console handlers for warning and error messages to stderr
     cerr = logging.StreamHandler(sys.stderr)
     cerr.setLevel(logging.WARNING)
     cerr.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    cerr.addFilter(MPIRankFilter())
     module_logger.addHandler(cerr)
 
     # Optionally set up a more comprehensive file handler
@@ -87,4 +110,5 @@ def configure_logger(
         fout.setFormatter(
             logging.Formatter("%(asctime)s %(name)-12s %(levelname)-4s: %(message)s")
         )
+        fout.addFilter(MPIRankFilter())
         module_logger.addHandler(fout)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,8 +1,9 @@
 import logging
 
 import pytest
+from mpi4py import MPI
 
-from pyc2ray.utils.logutils import configure_logger, disable_newline
+from pyc2ray.utils.logutils import allow_rank_logging, configure_logger, disable_newline
 
 
 def logging_function(logger: logging.Logger):
@@ -92,3 +93,19 @@ def test_disable_newline(logger, caplog, capsys):
     assert len(caplog.records) == 3
     out, _ = capsys.readouterr()
     assert out == "First part Second part\nThird part\n"
+
+
+def test_allow_rank_logging(logger, caplog, capsys):
+    configure_logger()
+
+    rank = MPI.COMM_WORLD.Get_rank()
+    with allow_rank_logging(rank):
+        logger.info(f"From rank {rank}")
+    logger.info("From root")
+
+    assert len(caplog.records) == 2
+    out, _ = capsys.readouterr()
+    if rank == 0:
+        assert out == "From rank 0\nFrom root\n"
+    else:
+        assert out == f"From rank {rank}\n"


### PR DESCRIPTION
As the title suggests, we add an utility to enable logging on other MPI ranks than the root process. Logging is , however, **not** synchronized and therefore output messages can mix up.

Depends on #63 
