### PR TITLE
Ensure column density buffer instead of one-off allocation

### DIFF
--- a/src/asora/memory.cpp
+++ b/src/asora/memory.cpp
@@ -101,13 +101,13 @@ namespace asora {
         auto &&[it, success] = _memory_pool.try_emplace(tag, nbytes);
 
         // Reallocate if existing buffer is too small
-        if (ensure && it->second.size() < nbytes) {
-            it->second = device_buffer(nbytes);
-            success = true;
-        }
+        if (ensure && it->second.size() < nbytes) it->second = device_buffer(nbytes);
 
         // Throw if tag exists but no copy requested, otherwise copy data
-        if (!success && !src) throw std::runtime_error("tag already in use");
+        if (!success && !ensure && !src)
+            throw std::runtime_error(
+                std::format("tag {} already in use", static_cast<int>(tag))
+            );
         if (src) it->second.copyFromHost(src, nbytes);
     }
 

--- a/src/asora/memory.h
+++ b/src/asora/memory.h
@@ -131,30 +131,30 @@ namespace asora {
      * allowing type-safe access to simulation data structures.
      */
     enum class buffer_tag {
-        number_density,          ///< Matter number density
-        fraction_HII,            ///< Hydrogen II fraction
-        fraction_HeII,           ///< Helium II fraction
-        fraction_HeIII,          ///< Helium III fraction
-        cross_section_HI,        ///< Ionization cross-section for HI
-        cross_section_HeI,       ///< Ionization cross-section for HeI
-        cross_section_HeII,      ///< Ionization cross-section for HeII
-        photo_ionization_HI,     ///< Photoionization rates for HI
-        photo_ionization_HeI,    ///< Photoionization rates for HeI
-        photo_ionization_HeII,   ///< Photoionization rates for HeII
-        photo_heating_HI,        ///< Photoheating rates for HI
-        photo_heating_HeI,       ///< Photoheating rates for HeI
-        photo_heating_HeII,      ///< Photoheating rates for HeII
-        column_density_HI,       ///< Column density along rays for HI
-        column_density_HeI,      ///< Column density along rays for HeI
-        column_density_HeII,     ///< Column density along rays for HeII
-        photo_ion_thin_table,    ///< Lookup table for optically thin photoionization
-        photo_ion_thick_table,   ///< Lookup table for optically thick photoionization
-        photo_heat_thin_table,   ///< Lookup table for optically thin photoheating
-        photo_heat_thick_table,  ///< Lookup table for optically thick photoheating
-        source_flux,             ///< Source flux array
-        source_position,         ///< Source position array
-        temperature,             ///< Gas temperature array
-        clumping_factor,         ///< Clumping factor array
+        number_density,          ///< Matter number density (0)
+        fraction_HII,            ///< Hydrogen II fraction (1)
+        fraction_HeII,           ///< Helium II fraction (2)
+        fraction_HeIII,          ///< Helium III fraction (3)
+        cross_section_HI,        ///< Ionization cross-section for HI (4)
+        cross_section_HeI,       ///< Ionization cross-section for HeI (5)
+        cross_section_HeII,      ///< Ionization cross-section for HeII (6)
+        photo_ionization_HI,     ///< Photoionization rates for HI (7)
+        photo_ionization_HeI,    ///< Photoionization rates for HeI (8)
+        photo_ionization_HeII,   ///< Photoionization rates for HeII (9)
+        photo_heating_HI,        ///< Photoheating rates for HI (10)
+        photo_heating_HeI,       ///< Photoheating rates for HeI (11)
+        photo_heating_HeII,      ///< Photoheating rates for HeII (12)
+        column_density_HI,       ///< Column density along rays for HI (13)
+        column_density_HeI,      ///< Column density along rays for HeI (14)
+        column_density_HeII,     ///< Column density along rays for HeII (15)
+        photo_ion_thin_table,    ///< Lookup table for optically thin photoion. (16)
+        photo_ion_thick_table,   ///< Lookup table for optically thick photoion. (17)
+        photo_heat_thin_table,   ///< Lookup table for optically thin photoheating (18)
+        photo_heat_thick_table,  ///< Lookup table for optically thick photoheating (19)
+        source_flux,             ///< Source flux array (20)
+        source_position,         ///< Source position array (21)
+        temperature,             ///< Gas temperature array (22)
+        clumping_factor,         ///< Clumping factor array (23)
     };
 
     /* @brief Singleton managing only one GPU device and its memory pool.

--- a/src/asora/raytracing.cu
+++ b/src/asora/raytracing.cu
@@ -145,8 +145,7 @@ namespace asora {
 
         // Allocate (if necessary) and zero the output array for the photoionization
         // rate
-        if (!device::contains(buffer_tag::photo_ionization_HI))
-            device::add<double>(buffer_tag::photo_ionization_HI, n_cells);
+        device::ensure<double>(buffer_tag::photo_ionization_HI, n_cells);
         auto phi_buf = device::get(buffer_tag::photo_ionization_HI);
         auto phi_d = phi_buf.data<double>();
         safe_cuda(cudaMemset(phi_d, 0, phi_buf.size()));
@@ -156,10 +155,9 @@ namespace asora {
         // faces of the octahedron. To raytrace the whole volume, the octahedron must
         // be 1.5*N in size. Allocate (if necessary) the column density array.
         int q_max = std::ceil(c::sqrt3<> * std::min(R, c::sqrt3<> * m1 / 2.0));
-        if (!device::contains(buffer_tag::column_density_HI))
-            device::add<double>(
-                buffer_tag::column_density_HI, grid_size * cells_to_shell(q_max)
-            );
+        device::ensure<double>(
+            buffer_tag::column_density_HI, grid_size * cells_to_shell(q_max)
+        );
 
         // Get source properties, assuming the arrays are already on the device.
         if (!device::contains(buffer_tag::source_flux) ||
@@ -232,7 +230,7 @@ namespace asora {
 
         // Offset pointer to the outgoing column density array used for
         // interpolation (each block works on its own array).
-        int cd_offset = blockIdx.x * cells_to_shell(q_max);
+        size_t cd_offset = blockIdx.x * cells_to_shell(q_max);
         data_HI.column_density += cd_offset;
 
         // Calculate column density and photoionization rate for the source cell.


### PR DESCRIPTION
R_max can change and thus the octahedron for column density, therefore the column density buffer should be reallocated from time to time.

Depends on #62 