### PR TITLE
Exception message update

### DIFF
--- a/src/asora/memory.cpp
+++ b/src/asora/memory.cpp
@@ -34,17 +34,19 @@ namespace asora {
 
     void device_buffer::copyFromHost(const void *src, size_t nbytes) {
         if (size() < nbytes)
-            throw std::invalid_argument(
-                "requested more bytes to copy than the buffer size"
-            );
+            throw std::invalid_argument(std::format(
+                "copyFromHost size mismatch: device buffer has {} bytes, requested {} bytes",
+                size(), nbytes
+            ));
         safe_cuda(cudaMemcpy(data(), src, nbytes, cudaMemcpyHostToDevice));
     }
 
     void device_buffer::copyToHost(void *dst, size_t nbytes) const {
         if (size() < nbytes)
-            throw std::invalid_argument(
-                "requested more bytes to copy than the buffer size"
-            );
+            throw std::invalid_argument(std::format(
+                "copyToHost size mismatch: device buffer has {} bytes, requested {} bytes",
+                size(), nbytes
+            ));
         safe_cuda(cudaMemcpy(dst, data(), nbytes, cudaMemcpyDeviceToHost));
     }
 


### PR DESCRIPTION
I encountered this exception while testing the domain decomposition feature, because of an unwanted size change in ndens size and during the call to 

libasora.density_to_device(ndens_flat) 

I would suggest a change in the exception message to provide a clearer description of the issue and make it easier to find the failing function call. 