### PR TITLE
feat: added function to re-allocate GPU buffers according to mesh size variation

### DIFF
--- a/pyc2ray/asora_core.py
+++ b/pyc2ray/asora_core.py
@@ -10,6 +10,7 @@ __all__ = [
     "is_periodic_mode_active",
     "device_init",
     "device_close",
+    "prepare_grid_buffers",
     "photo_table_to_device",
 ]
 
@@ -59,6 +60,27 @@ def device_close() -> None:
     assert libasora is not None
     if libasora.is_device_init():
         libasora.device_close()
+
+
+@check_libasora
+def prepare_grid_buffers(
+    grid_edge_length: int, force_matching_size: bool = False
+) -> None:
+    """Ensure mesh-dependent device buffers exist for an m1^3 grid
+
+    Parameters
+    ----------
+    grid_edge_length : int
+        Grid edge length; buffers are sized for grid_edge_length**3 cells
+    force_matching_size : bool
+        If True, reallocate buffers when their current size does not match
+    """
+    assert libasora is not None
+    if not libasora.is_device_init():
+        raise RuntimeError(
+            "GPU not initialized. Please initialize it by calling device_init"
+        )
+    libasora.prepare_grid_buffers(grid_edge_length, force_matching_size)
 
 
 @check_libasora

--- a/src/asora/memory.cpp
+++ b/src/asora/memory.cpp
@@ -34,19 +34,25 @@ namespace asora {
 
     void device_buffer::copyFromHost(const void *src, size_t nbytes) {
         if (size() < nbytes)
-            throw std::invalid_argument(std::format(
-                "copyFromHost size mismatch: device buffer has {} bytes, requested {} bytes",
-                size(), nbytes
-            ));
+            throw std::invalid_argument(
+                std::format(
+                    "copyFromHost size mismatch: device buffer has {} bytes, requested "
+                    "{} bytes",
+                    size(), nbytes
+                )
+            );
         safe_cuda(cudaMemcpy(data(), src, nbytes, cudaMemcpyHostToDevice));
     }
 
     void device_buffer::copyToHost(void *dst, size_t nbytes) const {
         if (size() < nbytes)
-            throw std::invalid_argument(std::format(
-                "copyToHost size mismatch: device buffer has {} bytes, requested {} bytes",
-                size(), nbytes
-            ));
+            throw std::invalid_argument(
+                std::format(
+                    "copyToHost size mismatch: device buffer has {} bytes, requested "
+                    "{} bytes",
+                    size(), nbytes
+                )
+            );
         safe_cuda(cudaMemcpy(dst, data(), nbytes, cudaMemcpyDeviceToHost));
     }
 
@@ -97,20 +103,29 @@ namespace asora {
     }
 
     void device::allocate_or_copy(
-        buffer_tag tag, size_t nbytes, const void *src, bool ensure
+        buffer_tag tag, size_t nbytes, const void *src, bool ensure,
+        bool force_matching_size
     ) {
         check_initialized();
 
-        auto &&[it, success] = _memory_pool.try_emplace(tag, nbytes);
+        auto &&[it, inserted] = _memory_pool.try_emplace(tag, nbytes);
 
-        // Reallocate if existing buffer is too small
-        if (ensure && it->second.size() < nbytes) it->second = device_buffer(nbytes);
+        if (!inserted) {
+            if (ensure) {
+                // Ensure-mode is idempotent: keep existing buffer if sizing
+                // policy is satisfied, otherwise replace it.
+                const bool needs_realloc = force_matching_size
+                                               ? (it->second.size() != nbytes)
+                                               : (it->second.size() < nbytes);
+                if (needs_realloc) {
+                    it->second = device_buffer(nbytes);
+                }
+            } else if (!src) {
+                throw std::runtime_error("tag already in use");
+            }
+        }
 
-        // Throw if tag exists but no copy requested, otherwise copy data
-        if (!success && !ensure && !src)
-            throw std::runtime_error(
-                std::format("tag {} already in use", static_cast<int>(tag))
-            );
+        // Copy host data whenever a source pointer is provided.
         if (src) it->second.copyFromHost(src, nbytes);
     }
 

--- a/src/asora/memory.h
+++ b/src/asora/memory.h
@@ -208,6 +208,8 @@ namespace asora {
          *
          * It behaves like 'transfer', except that a new buffer device of the right size
          * is allocated if the existing one is smaller than the required size.
+         * If force_matching_size is true, the existing buffer must have exactly the
+         * required size, otherwise reallocation is triggered.
          *
          * @tparam T Element type
          * @param[in] tag Buffer identifier
@@ -215,8 +217,12 @@ namespace asora {
          * @param[in] items Number of elements to copy
          */
         template <typename T>
-        static void ensure_transfer(buffer_tag tag, const T *src, size_t items) {
-            instance().allocate_or_copy(tag, items * sizeof(T), src, true);
+        static void ensure_transfer(
+            buffer_tag tag, const T *src, size_t items, bool force_matching_size = false
+        ) {
+            instance().allocate_or_copy(
+                tag, items * sizeof(T), src, true, force_matching_size
+            );
         }
 
         /* @brief Allocate an empty buffer on device and add it to the pool.
@@ -232,14 +238,22 @@ namespace asora {
         }
 
         /* @brief Ensure there is a buffer with the given tag and the required size.
+         * If force_matching_size is true, the existing buffer must have exactly the
+         * required size.
          *
          * @tparam T Element type
          * @param[in] tag Buffer identifier
          * @param[in] items Number of elements to allocate
+         * @param[in] force_matching_size If true, the existing buffer must have exactly
+         * the required size
          */
         template <typename T>
-        static void ensure(buffer_tag tag, size_t items) {
-            instance().allocate_or_copy(tag, items * sizeof(T), nullptr, true);
+        static void ensure(
+            buffer_tag tag, size_t items, bool force_matching_size = false
+        ) {
+            instance().allocate_or_copy(
+                tag, items * sizeof(T), nullptr, true, force_matching_size
+            );
         }
 
         /* @brief Retrieve a buffer from the device.
@@ -269,13 +283,16 @@ namespace asora {
          * @param[in] tag Buffer identifier
          * @param[in] nbytes Size in bytes
          * @param[in] src Optional host source pointer for copying
-         * @param[in] ensure Overwrite existing buffer if it is't large enough
-         * @throw std::runtime_error if tag exists but no copy requested and ensure is
-         * false
+         * @param[in] ensure Ensure a buffer exists according to sizing policy.
+         * @param[in] force_matching_size If ensure is true, enforce
+         * exact size match; when false, reuse existing buffers that are large
+         * enough and only reallocate when they are too small. Default is false.
+         * @throw std::runtime_error if tag exists but no copy requested and
+         * ensure is false
          */
         void allocate_or_copy(
             buffer_tag tag, size_t nbytes, const void *src = nullptr,
-            bool ensure = false
+            bool ensure = false, bool force_matching_size = false
         );
 
         /// Device ID (-1 means uninitialized)

--- a/src/asora/python_module.cu
+++ b/src/asora/python_module.cu
@@ -191,6 +191,33 @@ PyObject *asora_source_data_to_device([[maybe_unused]] PyObject *self, PyObject 
                : nullptr;
 }
 
+/// Ensure mesh-dependent buffers exist with the expected size.
+PyObject *asora_prepare_grid_buffers([[maybe_unused]] PyObject *self, PyObject *args) {
+    size_t m1;
+    int force_matching_size = 0;
+    if (!PyArg_ParseTuple(args, "k|p", &m1, &force_matching_size)) return nullptr;
+
+    auto n_cells = m1 * m1 * m1;
+    try {
+        asora::device::ensure<double>(
+            asora::buffer_tag::number_density, n_cells,
+            static_cast<bool>(force_matching_size)
+        );
+        asora::device::ensure<double>(
+            asora::buffer_tag::fraction_HII, n_cells,
+            static_cast<bool>(force_matching_size)
+        );
+        asora::device::ensure<double>(
+            asora::buffer_tag::photo_ionization_HI, n_cells,
+            static_cast<bool>(force_matching_size)
+        );
+    } catch (const std::exception &e) {
+        PyErr_SetString(PyExc_RuntimeError, e.what());
+        return nullptr;
+    }
+    return Py_None;
+}
+
 PyObject *asora_chemistry_global_pass([[maybe_unused]] PyObject *self, PyObject *args) {
     double dt;
     PyArrayObject *temp;
@@ -253,6 +280,8 @@ static PyMethodDef asoraMethods[] = {
      "Copy radiation tables to the device"},
     {"source_data_to_device", asora_source_data_to_device, METH_VARARGS,
      "Copy source data to the device"},
+    {"prepare_grid_buffers", asora_prepare_grid_buffers, METH_VARARGS,
+     "Ensure grid buffers are allocated with exact size for mesh m1"},
     {"chemistry_global_pass", asora_chemistry_global_pass, METH_VARARGS,
      "Solve chemistry ODE"},
     {NULL, NULL, 0, NULL} /* Sentinel */

--- a/tests/test_asora.py
+++ b/tests/test_asora.py
@@ -166,3 +166,31 @@ class TestLibasora:
         libasora.source_data_to_device(*create_source_data(50))
         libasora.source_data_to_device(*create_source_data(100))
         libasora.source_data_to_device(*create_source_data(80))
+
+    def test_prepare_grid_buffers(self, init_device):
+        # One argument required
+        with pytest.raises(TypeError):
+            libasora.prepare_grid_buffers()
+
+        # More than two arguments is invalid
+        with pytest.raises(TypeError):
+            libasora.prepare_grid_buffers(16, False, 0)
+
+        # Exercise both default mode and exact-size-forcing mode.
+        libasora.prepare_grid_buffers(16)
+        libasora.prepare_grid_buffers(16, True)
+        libasora.prepare_grid_buffers(24, False)
+
+        # Verify subsequent number-density upload remains functional.
+        dens = np.full(24**3, 0.5, dtype=np.float64)
+        libasora.density_to_device(dens)
+
+    def test_prepare_grid_buffers_forced_mode_idempotent(self, init_device):
+        # Repeated exact-size enforcement should be idempotent and not raise.
+        libasora.prepare_grid_buffers(20, True)
+        libasora.prepare_grid_buffers(20, True)
+        libasora.prepare_grid_buffers(20, True)
+
+        # Keep integration-level sanity check with a matching density upload.
+        dens = np.full(20**3, 0.5, dtype=np.float64)
+        libasora.density_to_device(dens)


### PR DESCRIPTION
When domain decomposition is enabled, the evolve3D function requires each MPI task to execute libasora.do_all_sources on multiple source groups characterized by different subdomain sizes. As a consequence, GPU memory for number_density, fraction_HII, and photo_ionization_HI must be allocated and/or reallocated whenever the subdomain size changes.