### PR TITLE
Skip refcheck for resize and fix astropy to 7.2.1

### DIFF
--- a/pyc2ray/domain/regular_grid.py
+++ b/pyc2ray/domain/regular_grid.py
@@ -324,7 +324,7 @@ class RegularGrid(Grid):
         target_shape = (self.num_cells, self.num_cells, self.num_cells)
         if local_field.shape != target_shape:
             try:
-                local_field.resize(target_shape)
+                local_field.resize(target_shape, refcheck=False)
             except ValueError as e:
                 raise ValueError(
                     f"Unable to resize local_field to match local grid shape: {e}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
+  "astropy==7.2.1",
   "h5py",
   "mpi4py==4.0.3",
   "numpy>=2",

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,12 +1,14 @@
+import pytest
+
 import pyc2ray.constants as c
 
 
 def test_constants():
-    assert c.year2s == 31557600.0
-    assert c.ev2fr == 241798924208491.78
-    assert c.ev2k == 11604.518121550082
-    assert c.pc == 3.0856775814913674e18
-    assert c.kpc == 3.0856775814913673e21
-    assert c.Mpc == 3.0856775814913676e24
-    assert c.msun2g == 1.988409870698051e33
-    assert c.m_p == 1.67262192369e-24
+    assert pytest.approx(c.year2s) == 31557600.0
+    assert pytest.approx(c.ev2fr) == 241798924208491.78
+    assert pytest.approx(c.ev2k) == 11604.518121550082
+    assert pytest.approx(c.pc) == 3.0856775814913674e18
+    assert pytest.approx(c.kpc) == 3.0856775814913673e21
+    assert pytest.approx(c.Mpc) == 3.0856775814913676e24
+    assert pytest.approx(c.msun2g) == 1.988409870698051e33
+    assert pytest.approx(c.m_p) == 1.67262192369e-24


### PR DESCRIPTION
Tests on main were failing on my machine because of some reference counting issue that would block the resize call. Is skipping reference check a good solution @ChristopherBignamini ?

Also, I am fixing the astropy version to 7.2.1 as the latest is now 8.0.0.