### PR TITLE
Fix lint action in GitHub workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,9 +57,7 @@ jobs:
       - name: Install clang-format
         run: pip install "clang-format>=22"
       - name: Check C++ and CUDA code style
-        run: >-
-          find src/ -regex '.*\.\(cu\|cuh\|cpp\|h\)' -exec clang-format -n
-          -Werror {} \;
+        run: find src/ -regex '.*\.\(cu\|cuh\|cpp\|h\)' | xargs clang-format -n -Werror
 
   lintmeson:
     name: Lint meson
@@ -69,4 +67,4 @@ jobs:
       - name: Install meson
         run: pip install meson
       - name: Check meson code style
-        run: 'find . -name meson.build -exec meson format -q {} \;'
+        run: find . -name meson.build | xargs meson format -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 lint = [
   "pre-commit",
   "ruff",
-  "clang-format",
+  "clang-format==21.1.2",
   "mypy",
   "meson",
   "types-PyYAML",

--- a/src/asora/memory.cpp
+++ b/src/asora/memory.cpp
@@ -34,19 +34,25 @@ namespace asora {
 
     void device_buffer::copyFromHost(const void *src, size_t nbytes) {
         if (size() < nbytes)
-            throw std::invalid_argument(std::format(
-                "copyFromHost size mismatch: device buffer has {} bytes, requested {} bytes",
-                size(), nbytes
-            ));
+            throw std::invalid_argument(
+                std::format(
+                    "copyFromHost size mismatch: device buffer has {} bytes, requested "
+                    "{} bytes",
+                    size(), nbytes
+                )
+            );
         safe_cuda(cudaMemcpy(data(), src, nbytes, cudaMemcpyHostToDevice));
     }
 
     void device_buffer::copyToHost(void *dst, size_t nbytes) const {
         if (size() < nbytes)
-            throw std::invalid_argument(std::format(
-                "copyToHost size mismatch: device buffer has {} bytes, requested {} bytes",
-                size(), nbytes
-            ));
+            throw std::invalid_argument(
+                std::format(
+                    "copyToHost size mismatch: device buffer has {} bytes, requested "
+                    "{} bytes",
+                    size(), nbytes
+                )
+            );
         safe_cuda(cudaMemcpy(dst, data(), nbytes, cudaMemcpyDeviceToHost));
     }
 


### PR DESCRIPTION
find ... -exec clang-format ... only returned the error code for find but not for the formatter. Changing the command to find ... | xargs clang-format ... returns the correct error code which is necessary to stop the CI.